### PR TITLE
fixing request doi endpoint

### DIFF
--- a/src/api_v0.py
+++ b/src/api_v0.py
@@ -767,6 +767,7 @@ def api_request_doi():
 		graceid = models.gw_alert.graceidfromalternate(graceid)
 		filter.append(models.pointing_event.graceid == graceid)
 		filter.append(models.pointing_event.pointingid == models.pointing.id)
+		filter.append(models.pointing.submitterid == user.id)
 
 	if "id" in args:
 		_id = args.get('id')
@@ -789,7 +790,7 @@ def api_request_doi():
 	gids, doi_points, warnings = [], [], []
 
 	for p in points:
-		if p.status == enums.pointing_status.completed and p.submitterid == user.id and p.doi_id == None:
+		if p.status == enums.pointing_status.completed and p.submitterid == user.id and p.doi_id is None:
 			doi_points.append(p)
 		else:
 			warnings.append("Invalid doi request for pointing: " + str(p.id))

--- a/src/api_v1.py
+++ b/src/api_v1.py
@@ -770,6 +770,7 @@ def api_request_doi_v1():
 		graceid = models.gw_alert.graceidfromalternate(graceid)
 		filter.append(models.pointing_event.graceid == graceid)
 		filter.append(models.pointing_event.pointingid == models.pointing.id)
+		filter.append(models.pointing.submitterid == user.id)
 
 	if "id" in args:
 		_id = args.get('id')
@@ -792,7 +793,7 @@ def api_request_doi_v1():
 	gids, doi_points, warnings = [], [], []
 
 	for p in points:
-		if p.status == enums.pointing_status.completed and p.submitterid == user.id and p.doi_id == None:
+		if p.status == enums.pointing_status.completed and p.submitterid == user.id and p.doi_id is None:
 			doi_points.append(p)
 		else:
 			warnings.append("Invalid doi request for pointing: " + str(p.id))

--- a/src/function.py
+++ b/src/function.py
@@ -601,10 +601,9 @@ def send_password_reset_email(user):
 def create_pointing_doi(points, graceid, creators, insts):
     points_json = []
 
-    print(insts)
     for p in points:
         if p.status == enums.pointing_status.completed:
-            points_json.append(p.json)
+            points_json.append(p.parse)
 
     if len(insts) > 1:
         inst_str = "These observations were taken on the"
@@ -617,8 +616,6 @@ def create_pointing_doi(points, graceid, creators, insts):
         inst_str += " instruments."
     else:
         inst_str = "These observations were taken on the " + insts[0] + " instrument."
-
-    print(len(points_json), creators, inst_str)
 
     if len(points_json):
         payload = {

--- a/src/models.py
+++ b/src/models.py
@@ -1215,11 +1215,12 @@ class gw_alert(db.Model):
     def alternatefromgraceid(graceid):
 
         alternateids = db.session.query(gw_alert).filter(
-            gw_alert.graceid == graceid
+            gw_alert.graceid == graceid,
+            gw_alert.alternateid != "",
+            gw_alert.alternateid is not None
         ).all()
         if len(alternateids):
-            if alternateids[0].alternateid is not None:
-                graceid = alternateids[0].alternateid
+            graceid = alternateids[0].alternateid
 
         return graceid
 


### PR DESCRIPTION
Fixes the "api/v1 (and v0)/request_doi" endpoint
makes sure it finds the correct graceid from alternate (this was broken)
makes sure the pointing query is for only the pointings associated with the api_token
outputs the json file in the correct format in the doi
