### PR TITLE
Update API endpoints error response code

### DIFF
--- a/src/api_v1.py
+++ b/src/api_v1.py
@@ -1022,7 +1022,7 @@ def get_gw_contours():
 		_file = gwtm_io.download_gwtm_file(filename=contourpath, source=config.STORAGE_BUCKET_SOURCE, config=config)
 		return make_response(_file, 200)
 	except: # noqa: E722
-		return make_response(f'Error in retrieving Contour file: {contourpath}', 200)
+		return make_response(f'Error in retrieving Contour file: {contourpath}', 404)
 
 
 @app.route('/api/v1/gw_skymap', methods=['GET'])
@@ -1062,7 +1062,7 @@ def get_gw_skymap():
 		_file = gwtm_io.download_gwtm_file(filename=skymap_path, source=config.STORAGE_BUCKET_SOURCE, config=config, decode=False)
 		return make_response(_file, 200)
 	except: # noqa: E722
-		return make_response(f'Error in retrieving Contour file: {skymap_path}', 200)
+		return make_response(f'Error in retrieving Contour file: {skymap_path}', 404)
 
 
 @app.route('/api/v1/grb_moc_file', methods=['GET'])
@@ -1099,7 +1099,7 @@ def get_grbmoc_v1():
 		_file = gwtm_io.download_gwtm_file(filename=moc_filepath, source=config.STORAGE_BUCKET_SOURCE, config=config)
 		return make_response(_file, 200)
 	except: # noqa: E722 
-		return make_response('MOC file for GW-Alert: \'{}\' and instrument: \'{}\' does not exist!'.format(gid, inst), 200)
+		return make_response('MOC file for GW-Alert: \'{}\' and instrument: \'{}\' does not exist!'.format(gid, inst), 404)
 
 
 @app.route('/api/v1/post_alert', methods=['POST'])


### PR DESCRIPTION
Per issue #70 the API endpoints were returning error code 200 for retrieval failure, which was misleading as error code 200 indicates operation success. We update the following API endpoints to report error code 404 upon retrieval failure:

- `/api/v1/gw_contour`
- `/api/v1/gw_skymap`
- `/api/v1/grb_moc_file`

The API endpoint now returns a 404 error if needed along with an error message describing what type of content was failed to retrieve.

Fixes #70