### PR TITLE
Added working Renorm Skymap button to the alert info page

### DIFF
--- a/src/forms.py
+++ b/src/forms.py
@@ -2,6 +2,7 @@ import astropy
 import pandas as pd
 import json
 import time
+from io import StringIO
 
 from flask_wtf import FlaskForm
 from flask_wtf.recaptcha import RecaptchaField
@@ -262,6 +263,7 @@ class AlertsForm(FlaskForm):
         }
 
         graceid = args['graceid']
+        renorm_skymap = args['renorm_skymap']
 
         self.viz = False
 
@@ -512,12 +514,22 @@ class AlertsForm(FlaskForm):
             self.avgra = self.selected_alert_info.avgra
             self.avgdec = self.selected_alert_info.avgdec
 
-            contourpath = f'{s3path}/'+path_info+'-contours-smooth.json'
+            if renorm_skymap:
+                #load cached renormalized skymap instead
+                contourpath = renorm_skymap
+                normed_cache = gwtm_io.get_cached_file(renorm_skymap, config)
+            else:
+                #load normal skymap
+                contourpath = f'{s3path}/'+path_info+'-contours-smooth.json'
             self.mappathinfo = mappathinfo
             #if it exists, add it to the overlay list
             try:
-                f = gwtm_io.download_gwtm_file(contourpath, config.STORAGE_BUCKET_SOURCE, config)
-                contours_data = pd.read_json(f)
+                if renorm_skymap:
+                    normed_result = json.loads(normed_cache)
+                    contours_data = pd.read_json(StringIO(normed_result['contours_json']))
+                else:
+                    f = gwtm_io.download_gwtm_file(contourpath, config.STORAGE_BUCKET_SOURCE, config)
+                    contours_data = pd.read_json(f)
                 contour_geometry = []
                 for contour in contours_data['features']:
                     contour_geometry.extend(contour['geometry']['coordinates'])

--- a/src/forms.py
+++ b/src/forms.py
@@ -263,7 +263,6 @@ class AlertsForm(FlaskForm):
         }
 
         graceid = args['graceid']
-        renorm_skymap = args['renorm_skymap']
 
         self.viz = False
 
@@ -514,22 +513,14 @@ class AlertsForm(FlaskForm):
             self.avgra = self.selected_alert_info.avgra
             self.avgdec = self.selected_alert_info.avgdec
 
-            if renorm_skymap:
-                #load cached renormalized skymap instead
-                contourpath = renorm_skymap
-                normed_cache = gwtm_io.get_cached_file(renorm_skymap, config)
-            else:
-                #load normal skymap
-                contourpath = f'{s3path}/'+path_info+'-contours-smooth.json'
+            #load normal skymap
+            contourpath = f'{s3path}/'+path_info+'-contours-smooth.json'
             self.mappathinfo = mappathinfo
             #if it exists, add it to the overlay list
             try:
-                if renorm_skymap:
-                    normed_result = json.loads(normed_cache)
-                    contours_data = pd.read_json(StringIO(normed_result['contours_json']))
-                else:
-                    f = gwtm_io.download_gwtm_file(contourpath, config.STORAGE_BUCKET_SOURCE, config)
-                    contours_data = pd.read_json(f)
+                
+                f = gwtm_io.download_gwtm_file(contourpath, config.STORAGE_BUCKET_SOURCE, config)
+                contours_data = pd.read_json(f)
                 contour_geometry = []
                 for contour in contours_data['features']:
                     contour_geometry.extend(contour['geometry']['coordinates'])

--- a/src/routes.py
+++ b/src/routes.py
@@ -295,10 +295,15 @@ def alerts():
 	status = request.args.get('pointing_status')
 	status = status if status is not None else 'completed'
 	alerttype = request.args.get('alert_type')
-	args = {'graceid':graceid, 'pointing_status':status, 'alert_type': alerttype}
+
+        # Get the optional JSON path argument for loading a renormed skymap
+	renorm_arg = request.args.get('normed_path', default=False)
+	
+	args = {'graceid':graceid, 'pointing_status':status, 'alert_type': alerttype, 'renorm_skymap':renorm_arg}
 	form = forms.AlertsForm
 	form.page = 'alerts'
 	form = form.construct_alertform(form, args)
+        
 	if graceid != 'None' and graceid is not None:
 		return render_template("alerts.html", form=form, detection_overlays=form.detection_overlays, GRBoverlays=form.GRBoverlays)
 

--- a/src/static/js/alert_aladin.js
+++ b/src/static/js/alert_aladin.js
@@ -217,7 +217,9 @@ function aladin_removeContour(
 }
 
 /*
-    Hides or shows an overlay from the checkbox
+    Hides or shows an overlay from the checkbox.
+    Checks color match: two insts should never have the same color,
+    but sometimes two insts (same network) can have the same name.
 */
 function aladin_overlayToggleOne(
     target,
@@ -226,7 +228,7 @@ function aladin_overlayToggleOne(
     var iter = 0
     for(var k=0; k<overlay_list.length; k++)
     {
-        if (target.id == overlay_list[k].contour.name) {
+        if (target.dataset.color == overlay_list[k].contour.color) {
             iter = k
         }
     }
@@ -378,7 +380,7 @@ function aladin_drawInstHTML(
             <li>\
                 <fieldset>\
                     <label for="' + cat.name + '" style="display: inline-block;">\
-                        <input id="' + cat.name + '" type="checkbox" value="' + cat.name + '" checked="checked" style="display: inline-block;"> \
+                        <input id="' + cat.name + '" type="checkbox" value="' + cat.name + '" data-color="' + cat.color + '" checked="checked" style="display: inline-block;"> \
                             <div class="overlaycolorbox" style="background-color: '+cat.color+';"></div>\
                             <span> '+cat.name+'</span>\
                         </input>\

--- a/src/static/js/alert_aladin.js
+++ b/src/static/js/alert_aladin.js
@@ -168,6 +168,9 @@ function aladin_setMarkers(
 /*
     Function that redraws the instrument contours based on the pointing time
     the slidervals come from the timeslider ui
+    Each contour with a distinct color is redrawn (not based on name)
+    since two insts should never have the same color but sometimes
+    two insts (same network) can have the same name.
 */
 function aladin_sliderRedrawContours(
     aladin, 
@@ -184,7 +187,7 @@ function aladin_sliderRedrawContours(
         var iter = 0
     
         for (j = 0; j < set_contour_list.length; j++) {
-            if (input_contour_list[i].name == set_contour_list[j].contour.name) {
+            if (input_contour_list[i].color == set_contour_list[j].tocolor) {
                 toshow = set_contour_list[j].toshow; 
                 tocolor = set_contour_list[j].tocolor; 
                 iter = j
@@ -228,7 +231,7 @@ function aladin_overlayToggleOne(
     var iter = 0
     for(var k=0; k<overlay_list.length; k++)
     {
-        if (target.dataset.color == overlay_list[k].contour.color) {
+        if (target.dataset.color == overlay_list[k].tocolor) {
             iter = k
         }
     }

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -383,8 +383,9 @@ text.info:hover span{ /*the span will display just on :hover state*/
     wavelengths, or depth. All fields are optional, but cuts on depths must have an associated unit. 
     If an empty form is submitted, the total reported coverage regardless of depth or band is computed. 
     Once a HEALPIX pixel has been first covered, it is marked as done, to avoid double counting probability 
-    when the same field is covered multiple times. After clicking, be patient, it may take up to 2 minutes 
+    when the same field is covered multiple times. After clicking Calculate, be patient, it may take up to 2 minutes 
     to fully compute the coverage profile.
+    You may also click Renorm Skymap to remove the selected pointings from the GW localization contours in the map above. 
   </i>
   <p style="color: red; font-size: small;">
     Disclaimer: The DECam Footprint currently breaks in the calculator. We are temporarily approximating its coverage as a circle with 1 deg radius.
@@ -455,7 +456,12 @@ text.info:hover span{ /*the span will display just on :hover state*/
   
 
   <br><br>
-  <input type="button" id="calculate" value="Calculate" class="btn btn-primary" style="display: block; margin: 0 auto;"/>
+  <div style="display: flex; justify-content: center; gap: 10px; margin: 0 auto;">
+    <input type="button" id="calculate" value="Calculate" class="btn btn-primary"/>
+    <input type="button" id="renorm-skymap" value="Renorm Skymap" class="btn btn-primary"/>
+  </div>
+  <!input type="button" id="calculate" value="Calculate" class="btn btn-primary" style="display: block; margin: 0 auto;"/>
+  <!input type="button" id="renorm-skymap" value="Renorm Skymap" class="btn btn-secondary"/>
 </div>
     
 <!-- Creation of Aladin Lite instance with initial parameters -->
@@ -803,6 +809,41 @@ text.info:hover span{ /*the span will display just on :hover state*/
     });
   });
 
+  //Function that renormalizes the skymap
+  $(document).ready( function() {
+      $('#renorm-skymap').click(function() {
+        $('#renorm-skymap').prop('disabled', true)
+        var btn = $(this).button('loading');
+        var inst_cov = $('#inst_cov').val()
+        var band_cov = $('#band_cov').val()
+        var depth_cov = $('#depth_cov').val()
+        var depth_unit = $('#depth_unit').val()
+        var approx_cov = $('#approx_cov').val()
+        var spectral_type = $('#spectral_range_type').val()
+        var spectral_unit = $('#spectral_range_unit').val()
+        var spectral_range_low = $('#spectral_range_low').val()
+        var spectral_range_high = $('#spectral_range_high').val()
+
+        $.ajax(
+          {
+              url: '/ajax_renormalize_skymap',
+              data: 'graceid={{ form.graceid }}&mappathinfo={{ form.mappathinfo }}&inst_cov='+inst_cov+'&band_cov='+band_cov+'&depth_cov='+depth_cov+'&depth_unit='+depth_unit+'&approx_cov='+approx_cov+'&spec_range_type='+spectral_type+'&spec_range_unit='+spectral_unit+'&spec_range_low='+spectral_range_low+'&spec_range_high='+spectral_range_high
+          }
+        ).done(function (reply) 
+          {
+            $('#renorm-skymap').prop('disabled', false)
+            window.location.href = '/alerts?graceids={{ form.graceid }}&normed_path=' + reply;
+          }
+        ).fail(function(jqXHR, textStatus)
+          {
+            $('#renorm-skymap').prop('disabled', false)
+            $('#coveragediv').html("<i><font color='red'>Error in Renormalize Skymap</font></i>")
+            btn.button('reset')
+          }
+      );
+    });
+  });
+  
   //getting the alert event galaxies
   $(document).ready( function() {
     $('#alert_event_galaxies').click(function() {

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -485,7 +485,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
   var slider_vals = [(slider_min), (slider_max)];
 
 </script>
-<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js', v=12353) }}"></script>
+<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js') }}"></script>
 <script type='text/javascript'>
   var data = {
     detection_overlays: detection_overlays,

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -835,7 +835,19 @@ text.info:hover span{ /*the span will display just on :hover state*/
         ).done(function (reply) 
           {
             $('#renorm-skymap').prop('disabled', false)
-            window.location.href = '/alerts?graceids={{ form.graceid }}&normed_path=' + reply;
+	    //reload aladin with the normed skymap contour
+	    aladin.removeLayers()
+            data.detection_overlays = reply.detection_overlays;
+            d = overlayInit(aladin, data)
+            //aladin.animateToRaDec(payload.alert_avgra, payload.alert_avgdec, 2);
+            detectionoverlaylist = d.detectionoverlaylist
+            instoverlaylist = d.instoverlaylist
+            grboverlaylist = d.grboverlaylist
+	    
+	    $('#coveragediv').html("<i><font color='#e6194B'>The Skymap has been Renormalized (~ look up! ~)</font></i>")
+
+	    //used to just reload the window with a path to the cache
+	    //window.location.href = '/alerts?graceids={{ form.graceid }}&normed_path=' + reply;
           }
         ).fail(function(jqXHR, textStatus)
           {

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -519,6 +519,9 @@ text.info:hover span{ /*the span will display just on :hover state*/
       }
     ).done( function(payload){
       aladin.removeLayers()
+      aladin_setImage(aladin, 'static/sun-logo-100.png', 'Sun at GW T0', data.sun_ra, data.sun_dec)
+      aladin_setImage(aladin, 'static/moon-supersmall.png', 'Moon at GW T0', data.moon_ra, data.moon_dec)
+	
       data.inst_overlays = payload
       aladin_drawInstHTML(data.inst_overlays, 'alert_instruments_div')
       instoverlaylist = aladin_setContours(aladin, payload)

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -485,7 +485,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
   var slider_vals = [(slider_min), (slider_max)];
 
 </script>
-<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js') }}"></script>
+<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js', v=12353) }}"></script>
 <script type='text/javascript'>
   var data = {
     detection_overlays: detection_overlays,


### PR DESCRIPTION
Added working Renorm Skymap button to the alert info page, currently uses the same information as coverage calculator which is queried through its form.

Thus, it is able to remove pointings by specific telescope, in specific bands, observations to certain depth, or within certain wavelength from the skymap based on user input.

### Test cases
Working for event S240422ed.

**Case 1:** selected only the WINTER, KMTNet, DECam telescopes, resulting renormalized skymap with those telescope pointings removed is shown in the image below.
<img width="232" alt="Screenshot 2025-02-02 at 6 04 30 PM" src="https://github.com/user-attachments/assets/99214f9d-66f4-4443-ad36-805389a3f17d" />
**Other cases:** Also working for all combinations of those telescopes, as well as for ZTF.
