### PR TITLE
Bug-fix: same-name instruments fail to toggle in drop-down menu

### DIFF
--- a/src/static/js/alert_aladin.js
+++ b/src/static/js/alert_aladin.js
@@ -217,7 +217,9 @@ function aladin_removeContour(
 }
 
 /*
-    Hides or shows an overlay from the checkbox
+    Hides or shows an overlay from the checkbox.
+    Checks color match: two insts should never have the same color,
+    but sometimes two insts (same network) can have the same name.
 */
 function aladin_overlayToggleOne(
     target,
@@ -226,7 +228,7 @@ function aladin_overlayToggleOne(
     var iter = 0
     for(var k=0; k<overlay_list.length; k++)
     {
-        if (target.id == overlay_list[k].contour.name) {
+        if (target.dataset.color == overlay_list[k].contour.color) {
             iter = k
         }
     }
@@ -378,7 +380,7 @@ function aladin_drawInstHTML(
             <li>\
                 <fieldset>\
                     <label for="' + cat.name + '" style="display: inline-block;">\
-                        <input id="' + cat.name + '" type="checkbox" value="' + cat.name + '" checked="checked" style="display: inline-block;"> \
+                        <input id="' + cat.name + '" type="checkbox" value="' + cat.name + '" data-color="' + cat.color + '" checked="checked" style="display: inline-block;"> \
                             <div class="overlaycolorbox" style="background-color: '+cat.color+';"></div>\
                             <span> '+cat.name+'</span>\
                         </input>\

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -479,7 +479,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
   var slider_vals = [(slider_min), (slider_max)];
 
 </script>
-<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js') }}"></script>
+<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js', v=12353) }}"></script>
 <script type='text/javascript'>
   var data = {
     detection_overlays: detection_overlays,

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -479,7 +479,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
   var slider_vals = [(slider_min), (slider_max)];
 
 </script>
-<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js', v=12353) }}"></script>
+<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js') }}"></script>
 <script type='text/javascript'>
   var data = {
     detection_overlays: detection_overlays,


### PR DESCRIPTION
This PR fixes #74

See test case below for MASTER telescope pointings of S250206dm.
First image: two instances of MASTER (turquoise and pink) are toggled off.
Second image: turquoise instance of MASTER is toggled on (pink still off).
Third image: pink instance of MASTER is toggled on (turquoise off).

<img width="1015" alt="Screenshot 2025-03-20 at 6 52 16 PM" src="https://github.com/user-attachments/assets/673e26a5-ea62-49a8-819a-e846e2ae467f" />
<img width="1015" alt="Screenshot 2025-03-20 at 6 52 29 PM" src="https://github.com/user-attachments/assets/6c087f1b-0db5-4f67-85e5-848ed43c65db" />
<img width="1015" alt="Screenshot 2025-03-20 at 6 52 26 PM" src="https://github.com/user-attachments/assets/cb38f3cc-4b81-4542-9e78-8546a0a73425" />
