### PR TITLE
Bug-fix: same-name instruments causing drop-down toggles and time slider to fail.

### DIFF
--- a/src/static/js/alert_aladin.js
+++ b/src/static/js/alert_aladin.js
@@ -217,7 +217,9 @@ function aladin_removeContour(
 }
 
 /*
-    Hides or shows an overlay from the checkbox
+    Hides or shows an overlay from the checkbox.
+    Checks color match: two insts should never have the same color,
+    but sometimes two insts (same network) can have the same name.
 */
 function aladin_overlayToggleOne(
     target,
@@ -226,7 +228,7 @@ function aladin_overlayToggleOne(
     var iter = 0
     for(var k=0; k<overlay_list.length; k++)
     {
-        if (target.id == overlay_list[k].contour.name) {
+        if (target.dataset.color == overlay_list[k].contour.color) {
             iter = k
         }
     }
@@ -378,7 +380,7 @@ function aladin_drawInstHTML(
             <li>\
                 <fieldset>\
                     <label for="' + cat.name + '" style="display: inline-block;">\
-                        <input id="' + cat.name + '" type="checkbox" value="' + cat.name + '" checked="checked" style="display: inline-block;"> \
+                        <input id="' + cat.name + '" type="checkbox" value="' + cat.name + '" data-color="' + cat.color + '" checked="checked" style="display: inline-block;"> \
                             <div class="overlaycolorbox" style="background-color: '+cat.color+';"></div>\
                             <span> '+cat.name+'</span>\
                         </input>\

--- a/src/static/js/alert_aladin.js
+++ b/src/static/js/alert_aladin.js
@@ -168,6 +168,9 @@ function aladin_setMarkers(
 /*
     Function that redraws the instrument contours based on the pointing time
     the slidervals come from the timeslider ui
+    Each contour with a distinct color is redrawn (not based on name)
+    since two insts should never have the same color but sometimes
+    two insts (same network) can have the same name.
 */
 function aladin_sliderRedrawContours(
     aladin, 
@@ -184,7 +187,7 @@ function aladin_sliderRedrawContours(
         var iter = 0
     
         for (j = 0; j < set_contour_list.length; j++) {
-            if (input_contour_list[i].name == set_contour_list[j].contour.name) {
+            if (input_contour_list[i].color == set_contour_list[j].tocolor) {
                 toshow = set_contour_list[j].toshow; 
                 tocolor = set_contour_list[j].tocolor; 
                 iter = j
@@ -228,7 +231,7 @@ function aladin_overlayToggleOne(
     var iter = 0
     for(var k=0; k<overlay_list.length; k++)
     {
-        if (target.dataset.color == overlay_list[k].contour.color) {
+        if (target.dataset.color == overlay_list[k].tocolor) {
             iter = k
         }
     }

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -479,7 +479,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
   var slider_vals = [(slider_min), (slider_max)];
 
 </script>
-<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js') }}"></script>
+<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js', v=12353) }}"></script>
 <script type='text/javascript'>
   var data = {
     detection_overlays: detection_overlays,

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -479,7 +479,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
   var slider_vals = [(slider_min), (slider_max)];
 
 </script>
-<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js', v=12353) }}"></script>
+<script type='text/javascript' src="{{ url_for('static',filename='js/alert_aladin.js') }}"></script>
 <script type='text/javascript'>
   var data = {
     detection_overlays: detection_overlays,

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -513,6 +513,9 @@ text.info:hover span{ /*the span will display just on :hover state*/
       }
     ).done( function(payload){
       aladin.removeLayers()
+      aladin_setImage(aladin, 'static/sun-logo-100.png', 'Sun at GW T0', data.sun_ra, data.sun_dec)
+      aladin_setImage(aladin, 'static/moon-supersmall.png', 'Moon at GW T0', data.moon_ra, data.moon_dec)
+	
       data.inst_overlays = payload
       aladin_drawInstHTML(data.inst_overlays, 'alert_instruments_div')
       instoverlaylist = aladin_setContours(aladin, payload)


### PR DESCRIPTION
Fixes instrument overlay toggling issue (#74) in the dropdown menu caused by same-named instrument.
Fixes time-slider coloring issue (#77), also caused by same-named instrument.

Images below show:
(1) example [event](http://127.0.0.1:5000/alerts?graceids=S250206dm), 2 same-name instruments (MASTER) are visible in the dropdown.
(2) one of the same-named instruments (the second instance) is toggled off.
(3) time slider is used to revert the map to a time before 1 of the yellow pointings was completed (removing it).
![Screenshot 2025-03-25 at 5 01 08 PM](https://github.com/user-attachments/assets/6c76e9b0-d263-400c-b844-9f889b4765e5)
![Screenshot 2025-03-25 at 5 01 49 PM](https://github.com/user-attachments/assets/aa452200-8ce0-49b2-b8fe-8b30f5ef3277)
![Screenshot 2025-03-25 at 5 02 03 PM](https://github.com/user-attachments/assets/dcf34302-6eeb-48ca-99f5-c9e642a29768)
