### PR TITLE
bug: Renorm skymap visualization taking into account gw alert ID in the cache key

### DIFF
--- a/src/ajaxrequests.py
+++ b/src/ajaxrequests.py
@@ -808,7 +808,7 @@ def plot_renormalized_skymap():
 	if inst_cov != '':
 		insts_cov = [int(x) for x in inst_cov.split(',')]
 		insts_cov = models.pointing.instrumentid.in_(insts_cov)
-		comp_mask &= comp_mask
+		comp_mask &= insts_cov
 	#take planned pointings if any selected
 	if inst_plan != '':
 		plan_mask = models.pointing.status == 'planned'

--- a/src/ajaxrequests.py
+++ b/src/ajaxrequests.py
@@ -784,6 +784,7 @@ def plot_renormalized_skymap():
 	start = time.time()
 
 	graceid = models.gw_alert.graceidfromalternate(request.args.get('graceid'))
+	alert_id = request.args.get('alert_id')
 	inst_cov = request.args.get('inst_cov')
 	inst_plan = request.args.get('inst_plan')
 	depth = request.args.get('depth_cov')
@@ -889,6 +890,7 @@ def plot_renormalized_skymap():
 	pointingids = sorted(pointingids)
 	hashpointingids =  hashlib.sha1(json.dumps(pointingids).encode()).hexdigest()
 
+	cache_key = f"normed_skymap_{graceid}_{alert_id}_{approx_cov}_{hashpointingids}"
 	#download the fits
 	if download:
 		#warning, this part is slow, so we only calculate this
@@ -927,7 +929,7 @@ def plot_renormalized_skymap():
 		#set file pointer to beginning of buffer for read
 		normed_skymap_bytes.seek(0)
 		#unique filename for download
-		dl_name = f'normed_skymap_{graceid}_{approx_cov}_{hashpointingids}.fits'
+		dl_name = f'{cache_key}.fits'
 		
 		#send file back as attachment
 		return send_file(
@@ -940,10 +942,12 @@ def plot_renormalized_skymap():
 		)
 
 	#otherwise, look for a cached contour file
-	cache_key = f'cache/normed_contours_{graceid}_{approx_cov}_{hashpointingids}'
+	cache_key_path = f'cache/{cache_key}'
+	print(cache_key_path)
 	#try to load a cached contour
-	cache_file = gwtm_io.get_cached_file(cache_key, config)
+	cache_file = gwtm_io.get_cached_file(cache_key_path, config)
 	if cache_file is None:
+		print('No cached contour found, calculating...')
 		#warning, this part is slow
 		normed_contours_json = gwtm_api.event_tools.renormed_skymap_contours(
 			graceid=graceid,
@@ -955,9 +959,10 @@ def plot_renormalized_skymap():
 		cache_file = {
 			'contours_json': normed_contours_json,
 		}
-		gwtm_io.set_cached_file(cache_key, cache_file, config)
+		gwtm_io.set_cached_file(cache_key_path, cache_file, config)
 	else:
 		#load cached contour
+		print('Using cached contour file')
 		normed_contours_json = json.loads(cache_file)['contours_json']
 
 	#read json and make detection overlay

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -1041,7 +1041,7 @@ text.info:hover span{ /*the span will display just on :hover state*/
         $.ajax(
           {
               url: '/ajax_renormalize_skymap',
-              data: 'graceid={{ form.graceid }}&mappathinfo={{ form.mappathinfo }}&alert_id='+alertid+'+&inst_cov='+inst_cov+'&inst_plan='+inst_plan+'&depth_cov='+depth_cov+'&depth_unit='+depth_unit+'&approx_cov='+approx_cov+'&spec_range_type='+spectral_type+'&spec_range_unit='+spectral_unit+'&spec_range_low='+spectral_range_low+'&spec_range_high='+spectral_range_high
+              data: 'graceid={{ form.graceid }}&mappathinfo={{ form.mappathinfo }}&alert_id='+alertid+'&inst_cov='+inst_cov+'&inst_plan='+inst_plan+'&depth_cov='+depth_cov+'&depth_unit='+depth_unit+'&approx_cov='+approx_cov+'&spec_range_type='+spectral_type+'&spec_range_unit='+spectral_unit+'&spec_range_low='+spectral_range_low+'&spec_range_high='+spectral_range_high
           }
         ).done(function (reply) {
 	        if (reply) {

--- a/src/templates/alert_info.html
+++ b/src/templates/alert_info.html
@@ -7,7 +7,6 @@
 }
 
 .slider {
-  -webkit-appearance: none;
   width: 100%;
   height: 25px;
   background: #d3d3d3;
@@ -878,9 +877,9 @@ text.info:hover span{ /*the span will display just on :hover state*/
         var actives = document.getElementsByClassName('nav-link active')
         var thisEl = document.getElementById(event.target.id)
         for(i = 0; i<actives.length; i++){
-	  if (!{{form.calc_ids|tojson}}.includes(actives[i].id)) {
-            actives[i].classList.remove('active')
-	  }
+          if (!'{{ form.calc_ids | tojson }}'.includes(actives[i].id)) {
+                  actives[i].classList.remove('active')
+          }
         }
         thisEl.classList.add('active')
 
@@ -966,27 +965,26 @@ text.info:hover span{ /*the span will display just on :hover state*/
   $(document).ready( function() {
     $('#calcnav').click(function(event) {
       if (event.target.id != 'calcnav' && event.target.id != 'calc-title') {
-	// Update tab style on click
-	var actives = document.getElementsByClassName('nav-link active')
+	      // Update tab style on click
+	      var actives = document.getElementsByClassName('nav-link active')
         var thisEl = document.getElementById(event.target.id)
         for(i = 0; i<actives.length; i++){
-	  if ({{form.calc_ids|tojson}}.includes(actives[i].id)) {
+          if ('{{ form.calc_ids | tojson }}'.includes(actives[i].id)) {
             actives[i].classList.remove('active')
-	  }
+	        }
         }
         thisEl.classList.add('active')
 
-	// Toggle tab content
-	actives = document.getElementsByClassName('tab-pane active')
-	thisEl = document.getElementById(event.target.dataset.tab)
-	for(i = 0; i<actives.length; i++){
-          actives[i].classList.remove('active')
-        }
+	      // Toggle tab content
+        actives = document.getElementsByClassName('tab-pane active')
+        thisEl = document.getElementById(event.target.dataset.tab)
+        for(i = 0; i<actives.length; i++){
+            actives[i].classList.remove('active')
+          }
         thisEl.classList.add('active')
       }
-    })
-  })
-  
+    });
+  });
   //Function that creates the Coverage plot
   $(document).ready( function() {
       $('#calculate').click(function() {
@@ -1027,10 +1025,10 @@ text.info:hover span{ /*the span will display just on :hover state*/
       $('#renorm-skymap').click(function() {
         $('#renorm-skymap').prop('disabled', true)
         var btn = $(this).button('loading');
-	$('#download-renorm').prop('disabled', true)
-	$('#download-renorm').button('loading')
+	      $('#download-renorm').prop('disabled', true)
+	      $('#download-renorm').button('loading')
         var inst_cov = $('#r_inst_cov').val()
-	var inst_plan = $('#r_inst_plan').val()
+	      var inst_plan = $('#r_inst_plan').val()
         var depth_cov = $('#r_depth_cov').val()
         var depth_unit = $('#r_depth_unit').val()
         var approx_cov = $('#r_approx_cov').val()
@@ -1038,45 +1036,42 @@ text.info:hover span{ /*the span will display just on :hover state*/
         var spectral_unit = $('#r_spectral_range_unit').val()
         var spectral_range_low = $('#r_spectral_range_low').val()
         var spectral_range_high = $('#r_spectral_range_high').val()
+        var alertid = document.getElementById('hidden_alertid').value;
 
         $.ajax(
           {
               url: '/ajax_renormalize_skymap',
-              data: 'graceid={{ form.graceid }}&mappathinfo={{ form.mappathinfo }}&inst_cov='+inst_cov+'&inst_plan='+inst_plan+'&depth_cov='+depth_cov+'&depth_unit='+depth_unit+'&approx_cov='+approx_cov+'&spec_range_type='+spectral_type+'&spec_range_unit='+spectral_unit+'&spec_range_low='+spectral_range_low+'&spec_range_high='+spectral_range_high
+              data: 'graceid={{ form.graceid }}&mappathinfo={{ form.mappathinfo }}&alert_id='+alertid+'+&inst_cov='+inst_cov+'&inst_plan='+inst_plan+'&depth_cov='+depth_cov+'&depth_unit='+depth_unit+'&approx_cov='+approx_cov+'&spec_range_type='+spectral_type+'&spec_range_unit='+spectral_unit+'&spec_range_low='+spectral_range_low+'&spec_range_high='+spectral_range_high
           }
-        ).done(function (reply) 
-          {
-	    if (reply) {
-	      //reload aladin with the normed skymap contour
-	      aladin.removeLayers()
-              data.detection_overlays = reply.detection_overlays;
-              d = overlayInit(aladin, data)
-              detectionoverlaylist = d.detectionoverlaylist
-              instoverlaylist = d.instoverlaylist
-              grboverlaylist = d.grboverlaylist
+        ).done(function (reply) {
+	        if (reply) {
+            //reload aladin with the normed skymap contour
+            aladin.removeLayers()
+            data.detection_overlays = reply.detection_overlays;
+            d = overlayInit(aladin, data)
+            detectionoverlaylist = d.detectionoverlaylist
+            instoverlaylist = d.instoverlaylist
+            grboverlaylist = d.grboverlaylist
 	    
-	      $('#renormdiv').html("<i><font color='#e6194B'>The Skymap has been Renormalized (~ look up! ~)</font></i>")
-	      btn.prop('disabled', false)
-              btn.button('reset')
-	      $('#download-renorm').prop('disabled', false)
-              $('#download-renorm').button('reset')
-	    } else {
-	      $('#renormdiv').html("<i><font color='#e6194B'>Done! No pointings selected.</font></i>")
-	      btn.prop('disabled', false)
-              btn.button('reset')
-              $('#download-renorm').prop('disabled', false)
-              $('#download-renorm').button('reset')
-            }
+	          $('#renormdiv').html("<i><font color='#e6194B'>The Skymap has been Renormalized (~ look up! ~)</font></i>")
+	          btn.prop('disabled', false)
+            btn.button('reset')
+	          $('#download-renorm').prop('disabled', false)
+            $('#download-renorm').button('reset')
+	        } else {
+	          $('#renormdiv').html("<i><font color='#e6194B'>Done! No pointings selected.</font></i>")
+	          btn.prop('disabled', false)
+            btn.button('reset')
+            $('#download-renorm').prop('disabled', false)
+            $('#download-renorm').button('reset')
           }
-        ).fail(function(jqXHR, textStatus)
-          {
+        }).fail(function(jqXHR, textStatus) {
             $('#renorm-skymap').prop('disabled', false)
-	    $('#download-renorm').prop('disabled', false)
+	          $('#download-renorm').prop('disabled', false)
             $('#renormdiv').html("<i><font color='red'>Error in Renormalize Skymap</font></i>")
             btn.button('reset')
             $('#download-renorm').button('reset')
-          }
-      );
+        });
     });
   });
 
@@ -1085,10 +1080,10 @@ text.info:hover span{ /*the span will display just on :hover state*/
       $('#download-renorm').click(function() {
         $('#download-renorm').prop('disabled', true)
         var btn = $(this).button('loading');
-	$('#renorm-skymap').prop('disabled', true)
-	$('#renorm-skymap').button('loading')
+        $('#renorm-skymap').prop('disabled', true)
+        $('#renorm-skymap').button('loading')
         var inst_cov = $('#r_inst_cov').val()
-	var inst_plan = $('#r_inst_plan').val()
+	      var inst_plan = $('#r_inst_plan').val()
         var depth_cov = $('#r_depth_cov').val()
         var depth_unit = $('#r_depth_unit').val()
         var approx_cov = $('#r_approx_cov').val()
@@ -1097,9 +1092,9 @@ text.info:hover span{ /*the span will display just on :hover state*/
         var spectral_range_low = $('#r_spectral_range_low').val()
         var spectral_range_high = $('#r_spectral_range_high').val()
 	
-	$('#renormdiv').html(`
-          <i>Generating fits file...</i>
-          <progress id="dl-progress-bar" value="0" max="100" style="width: 100%;"></progress>`);
+        $('#renormdiv').html(`
+                <i>Generating fits file...</i>
+                <progress id="dl-progress-bar" value="0" max="100" style="width: 100%;"></progress>`);
 
 	//animate progress bar from 0% to 90% over 300s
 	let progressVal = 0;
@@ -1118,9 +1113,9 @@ text.info:hover span{ /*the span will display just on :hover state*/
           {
               url: '/ajax_renormalize_skymap',
               data: 'graceid={{ form.graceid }}&mappathinfo={{ form.mappathinfo }}&inst_cov='+inst_cov+'&inst_plan='+inst_plan+'&depth_cov='+depth_cov+'&depth_unit='+depth_unit+'&approx_cov='+approx_cov+'&spec_range_type='+spectral_type+'&spec_range_unit='+spectral_unit+'&spec_range_low='+spectral_range_low+'&spec_range_high='+spectral_range_high+'&download=true&_ts='+Date.now(),
-	      xhrFields: {
-		  responseType: 'blob'
-	      }
+              xhrFields: {
+                responseType: 'blob'
+              }
           }
         ).done(function (reply, textStatus, jqXHR) 
           {
@@ -1129,16 +1124,16 @@ text.info:hover span{ /*the span will display just on :hover state*/
 	      $('#renormdiv').find('i').text("Downloading fits file...")
 	      $('#dl-progress-bar').val(90);
 
-              //parse filename of renormalized skymap from blob
+        //parse filename of renormalized skymap from blob
 	      const cDisp = jqXHR.getResponseHeader('Content-Disposition');
 	      let dl_name = 'normed_skymap.fits'; //placeholder
-	      if (cDisp && cDisp.indexOf('filename=') !== -1) {
-		//OK, Content-Disposition and filename both exist
-		dl_name = cDisp
-                .split('filename=')[1] //extract content following "filename="
-                .split(';')[0]         //toss everything after filename field
-                .replace(/"/g, '');    //clean double quotes
-              }				  
+        if (cDisp && cDisp.indexOf('filename=') !== -1) {
+          //OK, Content-Disposition and filename both exist
+          dl_name = cDisp
+          .split('filename=')[1] //extract content following "filename="
+          .split(';')[0]         //toss everything after filename field
+          .replace(/"/g, '');    //clean double quotes
+        }				  
 	      //download renormalized skymap
 	      const downloadUrl = URL.createObjectURL(reply);
 	      const tempa = document.createElement('a');
@@ -1167,10 +1162,10 @@ text.info:hover span{ /*the span will display just on :hover state*/
         ).fail(function(jqXHR, textStatus)
           {
             $('#download-renorm').prop('disabled', false)
-	    $('#renorm-skymap').prop('disabled', false)
+	          $('#renorm-skymap').prop('disabled', false)
             $('#renormdiv').html("<i><font color='red'>Error Downloading Renormalized Skymap</font></i>")
             btn.button('reset')
-	    $('#renorm-skymap').button('reset')
+	          $('#renorm-skymap').button('reset')
           }
       );
     });


### PR DESCRIPTION
### Description

This adds the alertid to the cache key for the renorm skymap cache calculation. The ensures that they will be unique when alerts get updated. This fix is different from the spec where it doesn't add the alert type name to the file, but the id, which will the same uniqueness.

Resolves https://github.com/TheTreasureMap/gwtm/issues/91

### NOTE

Also fixes a bug where it wasn't actually taking into account the selected drop down completed instrument pointings. 