### PR TITLE
Use a fixed version from the master branch of flask-profiler.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ fsspec
 adlfs
 s3fs==0.6.0
 markupsafe>=2.1.1
-flask_profiler==1.8.1
+git+https://github.com/muatik/flask-profiler.git@6a36526184ad3a903c2d50b3e208ed276d3404f6 # Fixed version from master


### PR DESCRIPTION
This error was seen in production:

> sqlalchemy.exc.DataError: (psycopg2.errors.NumericValueOutOfRange) numeric field overflow
> DETAIL:  A field with precision 6, scale 4 must round to an absolute value less than 10^2.
> 
> [SQL: INSERT INTO flask_profiler_measurements ("startedAt", "endedAt", elapsed, method, args, kwargs, name, context) VALUES (%(startedAt)s, %(endedAt)s, %(elapsed)s, %(method)s, %(args)s, %(kwargs)s, %(name)s, %(context)s) RETURNING flask_profiler_measurements.id]
> [parameters: {'startedAt': 1748547259, 'endedAt': 1748547441, 'elapsed': Decimal('182.0150'), 'method': 'GET', 'args': '[]', 'kwargs': '{}', 'name': '/alerts', 'context': '{"url": "http://127.0.0.1:5000/alerts", "args": {"graceids": "S250331o"}, "form": {}, "body": "", "headers": {"Host": "127.0.0.1:5000", "Connection": ... (639 characters truncated) ... 27.0.0.1:5000/alert_select", "Accept-Encoding": "gzip, deflate, br, zstd", "Accept-Language": "en-US,en;q=0.9"}, "func": "alerts", "ip": "127.0.0.1"}'}]

was a result of v1.8.1 of flask profiler defining the elasped time field as NUMERIC(6, 4) which means a total of 6 digits with 4 after the decimal point, i.e. max value 99.9999. Very long lasting queries like the 182 second example here exceed this limit and cause an error.

This PR uses the head of the master branch of the flask profiler which [has a larger capacity](https://github.com/muatik/flask-profiler/blob/6a36526184ad3a903c2d50b3e208ed276d3404f6/flask_profiler/storage/sql_alchemy.py#L25) to store elapsed time than the 1.8.1 tag, allowing recording of queries lasting up to 1,000,000 seconds (about 11 days) rather than 100 seconds.

We should also modify the live database table to make this change without re-creating the flask profiler table, i.e. 
`ALTER TABLE flask_profiler_measurements 
ALTER COLUMN elapsed TYPE NUMERIC(10,4);`