### PR TITLE
Add endpoint for admins to delete instruments added in error

### DIFF
--- a/frontend/src/routes/documentation/tutorial/+page.svelte
+++ b/frontend/src/routes/documentation/tutorial/+page.svelte
@@ -116,7 +116,7 @@ import requests
 API_TOKEN = "your_api_token_here"
 BASE_URL = "https://treasuremap.space/api/v1"
 
-headers = {'{'}"Authorization": f"Bearer {'{'}{API_TOKEN}}",
+headers = {'{'}"Authorization": f"Bearer {'{'}API_TOKEN}",
     "Content-Type": "application/json"
 }</code
 						></pre>
@@ -130,13 +130,13 @@ headers = {'{'}"Authorization": f"Bearer {'{'}{API_TOKEN}}",
 					<pre class="text-green-400 text-sm"><code
 							># Get pointings for a specific GW event
 response = requests.get(
-    f"{'{'}{BASE_URL}}/pointings",
+    f"{'{'}BASE_URL}/pointings",
     params={'{'}"graceid": "S190425z"},
     headers=headers
 )
 
 pointings = response.json()
-print(f"Found {'{'}{len(pointings)}} pointings for S190425z")</code
+print(f"Found {'{'}len(pointings)} pointings for S190425z")</code
 						></pre>
 				</div>
 			</div>
@@ -159,7 +159,7 @@ pointing_data = {'{'}"graceid": "S190425z",
 }
 
 response = requests.post(
-    f"{'{'}{BASE_URL}}/pointings",
+    f"{'{'}BASE_URL}/pointings",
     json=pointing_data,
     headers=headers
 )

--- a/server/auth/auth.py
+++ b/server/auth/auth.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from sqlalchemy import func
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 import jwt
 
 from server.config import settings
+from server.utils.audit import record_user_action
 
 # Define the API key header
 api_key_header = APIKeyHeader(name="api_token", auto_error=False)
@@ -67,6 +68,7 @@ def decode_token(token: str) -> dict:
 
 
 def get_current_user(
+    request: Request,
     api_token: Optional[str] = Depends(api_key_header),
     jwt_token: Optional[str] = Depends(oauth2_scheme),
     db: Session = Depends(get_db),
@@ -84,29 +86,27 @@ def get_current_user(
             user_id = payload.get("sub")
             if user_id:
                 user = db.query(Users).filter(Users.id == int(user_id)).first()
-                if user:
-                    return user
         except HTTPException:
             # JWT token is invalid, continue to try API token
-            pass
+            user = None
 
     # Fall back to API token (from api_token header)
-    if api_token:
+    if not user and api_token:
         user = db.query(Users).filter(Users.api_token == api_token).first()
-        if user:
-            return user
 
     # Also accept API token passed as a Bearer token (jwt_token that failed JWT decode)
-    if jwt_token:
+    if not user and jwt_token:
         user = db.query(Users).filter(Users.api_token == jwt_token).first()
-        if user:
-            return user
 
     # Neither token worked
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required. Please provide a valid JWT token or API token.",
-    )
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required. Please provide a valid JWT token or API token.",
+        )
+
+    record_user_action(user, request)
+    return user
 
 
 def verify_admin(
@@ -135,19 +135,3 @@ def verify_admin(
         )
 
     return user
-
-
-def log_user_action(
-    user: Users,
-    request_path: str,
-    method: str,
-    ip_address: str,
-    json_data=None,
-    db: Session = Depends(get_db),
-):
-    """
-    Log user actions for auditing
-    Will be implemented with full UserAction model
-    """
-    # This will be implemented when the UserAction model is fully ported
-    pass

--- a/server/routes/event/delete_candidate_event.py
+++ b/server/routes/event/delete_candidate_event.py
@@ -7,6 +7,7 @@ from server.db.database import get_db
 from server.db.models.candidate import GWCandidate
 from server.utils.error_handling import not_found_exception, permission_exception
 from server.auth.auth import get_current_user
+from server.utils.audit import log_admin_action
 from .utils import is_admin
 
 router = APIRouter(tags=["Events"])
@@ -25,10 +26,25 @@ async def delete_candidate_event(
         raise not_found_exception("Candidate not found")
 
     # Check if user is the owner or an admin
-    if db_candidate.submitterid != current_user.id and not is_admin(current_user, db):
+    is_owner = db_candidate.submitterid == current_user.id
+    if not is_owner and not is_admin(current_user, db):
         raise permission_exception("Not authorized to delete this candidate")
+
+    # Read off the details while the instance is still live; it is expired
+    # once the delete is committed.
+    candidate_name = db_candidate.candidate_name
+    graceid = db_candidate.graceid
 
     db.delete(db_candidate)
     db.commit()
+
+    log_admin_action(
+        current_user,
+        "candidate_event.delete",
+        f"candidate:{candidate_id}",
+        admin_override=not is_owner,
+        candidate_name=candidate_name,
+        graceid=graceid,
+    )
 
     return {"message": "Candidate deleted successfully"}

--- a/server/routes/event/update_candidate_event.py
+++ b/server/routes/event/update_candidate_event.py
@@ -8,6 +8,7 @@ from server.db.models.candidate import GWCandidate
 from server.schemas.candidate import GWCandidateSchema
 from server.utils.error_handling import not_found_exception, permission_exception
 from server.auth.auth import get_current_user
+from server.utils.audit import log_admin_action
 from .utils import is_admin
 
 router = APIRouter(tags=["Events"])
@@ -27,7 +28,8 @@ async def update_candidate_event(
         raise not_found_exception("Candidate not found")
 
     # Check if user is the owner or an admin
-    if db_candidate.submitterid != current_user.id and not is_admin(current_user, db):
+    is_owner = db_candidate.submitterid == current_user.id
+    if not is_owner and not is_admin(current_user, db):
         raise permission_exception("Not authorized to update this candidate")
 
     # Update fields
@@ -40,5 +42,14 @@ async def update_candidate_event(
 
     db.commit()
     db.refresh(db_candidate)
+
+    log_admin_action(
+        current_user,
+        "candidate_event.update",
+        f"candidate:{candidate_id}",
+        admin_override=not is_owner,
+        candidate_name=db_candidate.candidate_name,
+        graceid=db_candidate.graceid,
+    )
 
     return {"message": "Candidate updated successfully"}

--- a/server/routes/event/utils.py
+++ b/server/routes/event/utils.py
@@ -1,12 +1,13 @@
 """Utility functions for event routes."""
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from server.db.models.users import UserGroups, Groups
 
 
 def is_admin(user, db: Session) -> bool:
-    """Check if the user is an admin."""
-    admin_group = db.query(Groups).filter(Groups.name == "admin").first()
+    """Check if the user is an admin (case-insensitive group name match)."""
+    admin_group = db.query(Groups).filter(func.lower(Groups.name) == "admin").first()
     if not admin_group:
         return False
 

--- a/server/routes/instrument/delete_instrument.py
+++ b/server/routes/instrument/delete_instrument.py
@@ -1,0 +1,63 @@
+"""Delete instrument endpoint."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from server.db.database import get_db
+from server.db.models.instrument import Instrument, FootprintCCD
+from server.db.models.pointing import Pointing
+from server.schemas.instrument import DeleteInstrumentResponse
+from server.auth.auth import get_current_user
+from server.routes.event.utils import is_admin
+from server.utils.error_handling import (
+    not_found_exception,
+    permission_exception,
+    conflict_exception,
+)
+
+router = APIRouter(tags=["instruments"])
+
+
+@router.delete("/instruments/{instrument_id}", response_model=DeleteInstrumentResponse)
+async def delete_instrument(
+    instrument_id: int,
+    db: Session = Depends(get_db),
+    user=Depends(get_current_user),
+):
+    """Delete an instrument together with its footprint CCDs.
+
+    Only the instrument's submitter or an admin may delete it. Deletion is
+    refused while any pointing still references the instrument, since those
+    observation records would otherwise point at a missing instrument.
+    """
+    instrument = db.query(Instrument).filter(Instrument.id == instrument_id).first()
+    if not instrument:
+        raise not_found_exception(f"No instrument found with 'id': {instrument_id}")
+
+    if instrument.submitterid != user.id and not is_admin(user, db):
+        raise permission_exception(
+            "Error: Unauthorized. Unable to alter other user's records"
+        )
+
+    pointing_count = (
+        db.query(Pointing).filter(Pointing.instrumentid == instrument_id).count()
+    )
+    if pointing_count:
+        raise conflict_exception(
+            f"Instrument {instrument_id} is referenced by {pointing_count} "
+            "pointing(s) and cannot be deleted."
+        )
+
+    deleted_footprints = (
+        db.query(FootprintCCD)
+        .filter(FootprintCCD.instrumentid == instrument_id)
+        .delete()
+    )
+    db.delete(instrument)
+    db.commit()
+
+    return DeleteInstrumentResponse(
+        message=f"Successfully deleted instrument {instrument_id}",
+        deleted_id=instrument_id,
+        deleted_footprints=deleted_footprints,
+    )

--- a/server/routes/instrument/delete_instrument.py
+++ b/server/routes/instrument/delete_instrument.py
@@ -9,6 +9,7 @@ from server.db.models.pointing import Pointing
 from server.schemas.instrument import DeleteInstrumentResponse
 from server.auth.auth import get_current_user
 from server.routes.event.utils import is_admin
+from server.utils.audit import log_admin_action
 from server.utils.error_handling import (
     not_found_exception,
     permission_exception,
@@ -34,7 +35,8 @@ async def delete_instrument(
     if not instrument:
         raise not_found_exception(f"No instrument found with 'id': {instrument_id}")
 
-    if instrument.submitterid != user.id and not is_admin(user, db):
+    is_owner = instrument.submitterid == user.id
+    if not is_owner and not is_admin(user, db):
         raise permission_exception(
             "Error: Unauthorized. Unable to alter other user's records"
         )
@@ -48,6 +50,10 @@ async def delete_instrument(
             "pointing(s) and cannot be deleted."
         )
 
+    # Read off the name while the instance is still live; it is expired once
+    # the delete is committed.
+    instrument_name = instrument.instrument_name
+
     deleted_footprints = (
         db.query(FootprintCCD)
         .filter(FootprintCCD.instrumentid == instrument_id)
@@ -55,6 +61,15 @@ async def delete_instrument(
     )
     db.delete(instrument)
     db.commit()
+
+    log_admin_action(
+        user,
+        "instrument.delete",
+        f"instrument:{instrument_id}",
+        admin_override=not is_owner,
+        instrument_name=instrument_name,
+        deleted_footprints=deleted_footprints,
+    )
 
     return DeleteInstrumentResponse(
         message=f"Successfully deleted instrument {instrument_id}",

--- a/server/routes/instrument/router.py
+++ b/server/routes/instrument/router.py
@@ -7,6 +7,7 @@ from .get_instruments import router as get_instruments_router
 from .get_footprints import router as get_footprints_router
 from .create_instrument import router as create_instrument_router
 from .create_footprint import router as create_footprint_router
+from .delete_instrument import router as delete_instrument_router
 
 # Create the main router that includes all instrument routes
 router = APIRouter(tags=["instruments"])
@@ -16,3 +17,4 @@ router.include_router(get_instruments_router)
 router.include_router(get_footprints_router)
 router.include_router(create_instrument_router)
 router.include_router(create_footprint_router)
+router.include_router(delete_instrument_router)

--- a/server/routes/ui/resend_verification_email.py
+++ b/server/routes/ui/resend_verification_email.py
@@ -4,11 +4,13 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from server.db.database import get_db
 from server.db.models.users import Users, UserGroups, Groups
 from server.auth.auth import get_current_user
+from server.utils.audit import log_admin_action
 from server.utils.email import send_verification_email
 from server.utils.tokens import generate_verification_token
 
@@ -33,7 +35,9 @@ async def resend_verification_email(
     if email:
         # Authorise first — before touching the DB for the target user — so
         # non-admins always get 403 regardless of whether the email exists.
-        admin_group = db.query(Groups).filter(Groups.name == "admin").first()
+        admin_group = (
+            db.query(Groups).filter(func.lower(Groups.name) == "admin").first()
+        )
         is_admin = admin_group and db.query(UserGroups).filter(
             UserGroups.userid == current_user.id,
             UserGroups.groupid == admin_group.id,
@@ -66,6 +70,15 @@ async def resend_verification_email(
         raise HTTPException(
             status_code=503,
             detail="Unable to send verification email. Please try again later.",
+        )
+
+    if email:
+        log_admin_action(
+            current_user,
+            "verification_email.resend",
+            f"user:{user.id}",
+            admin_override=True,
+            target_username=user.username,
         )
 
     return {"message": "Verification email has been resent"}

--- a/server/routes/ui/resend_verification_email.py
+++ b/server/routes/ui/resend_verification_email.py
@@ -77,7 +77,7 @@ async def resend_verification_email(
             current_user,
             "verification_email.resend",
             f"user:{user.id}",
-            admin_override=True,
+            admin_override=user.id != current_user.id,
             target_username=user.username,
         )
 

--- a/server/schemas/instrument.py
+++ b/server/schemas/instrument.py
@@ -131,6 +131,16 @@ class InstrumentCreateResponse(BaseModel):
     )
 
 
+class DeleteInstrumentResponse(BaseModel):
+    """Response schema for instrument deletion."""
+
+    message: str = Field(..., description="Result message")
+    deleted_id: int = Field(..., description="ID of the deleted instrument")
+    deleted_footprints: int = Field(
+        ..., description="Number of footprint CCD rows removed with the instrument"
+    )
+
+
 class InstrumentUpdate(BaseModel):
     """Schema for updating an instrument."""
 

--- a/server/schemas/instrument.py
+++ b/server/schemas/instrument.py
@@ -55,9 +55,11 @@ class InstrumentSchema(BaseModel):
 class InstrumentCreate(BaseModel):
     """Schema for creating a new instrument with footprint."""
 
-    instrument_name: str = Field(..., description="Name of the instrument")
+    instrument_name: str = Field(
+        ..., max_length=100, description="Name of the instrument"
+    )
     nickname: Optional[str] = Field(
-        None, description="Nickname or short name for the instrument"
+        None, max_length=25, description="Nickname or short name for the instrument"
     )
     instrument_type: instrument_type_enum = Field(
         ..., description="Type of the instrument"
@@ -145,10 +147,12 @@ class InstrumentUpdate(BaseModel):
     """Schema for updating an instrument."""
 
     instrument_name: Optional[str] = Field(
-        None, description="Updated name of the instrument"
+        None, max_length=100, description="Updated name of the instrument"
     )
     nickname: Optional[str] = Field(
-        None, description="Updated nickname or short name for the instrument"
+        None,
+        max_length=25,
+        description="Updated nickname or short name for the instrument",
     )
     instrument_type: Optional[instrument_type_enum] = Field(
         None, description="Updated type of the instrument"

--- a/server/schemas/instrument.py
+++ b/server/schemas/instrument.py
@@ -56,7 +56,7 @@ class InstrumentCreate(BaseModel):
     """Schema for creating a new instrument with footprint."""
 
     instrument_name: str = Field(
-        ..., max_length=100, description="Name of the instrument"
+        ..., max_length=64, description="Name of the instrument"
     )
     nickname: Optional[str] = Field(
         None, max_length=25, description="Nickname or short name for the instrument"
@@ -147,7 +147,7 @@ class InstrumentUpdate(BaseModel):
     """Schema for updating an instrument."""
 
     instrument_name: Optional[str] = Field(
-        None, max_length=100, description="Updated name of the instrument"
+        None, max_length=64, description="Updated name of the instrument"
     )
     nickname: Optional[str] = Field(
         None,

--- a/server/utils/audit.py
+++ b/server/utils/audit.py
@@ -1,0 +1,92 @@
+"""Audit logging for privileged actions and authenticated requests."""
+
+import json
+import logging
+from datetime import datetime
+
+from server.db.database import db_session
+from server.db.models.users import UserActions
+
+logger = logging.getLogger("gwtm.audit")
+
+# public.useractions column widths.
+IPADDRESS_MAX = 50
+METHOD_MAX = 24
+
+# Bodies larger than this are not recorded.
+MAX_BODY_BYTES = 16384
+
+
+def log_admin_action(
+    user, action: str, target: str, *, admin_override: bool, **details
+):
+    """Record a privileged action against a resource.
+
+    admin_override marks an action taken on a record the user does not own,
+    which only admins are permitted to do.
+
+    Values are repr'd so that names containing spaces stay parseable as
+    key=value pairs.
+    """
+    fields = {
+        "action": action,
+        "target": target,
+        "userid": user.id,
+        "username": getattr(user, "username", None),
+        "admin_override": admin_override,
+        **details,
+    }
+    logger.info(" ".join(f"{key}={value!r}" for key, value in fields.items()))
+
+
+def client_ip(request):
+    """Client address, preferring the first hop in X-Forwarded-For."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()[:IPADDRESS_MAX]
+    if request.client:
+        return request.client.host[:IPADDRESS_MAX]
+    return None
+
+
+def request_body_json(request):
+    """The request's JSON body as a dict or list, or None.
+
+    Reads the body FastAPI has already buffered onto the request. A sync
+    dependency cannot await the stream itself, and re-reading it would
+    consume it before the endpoint sees it.
+    """
+    body = getattr(request, "_body", None)
+    if not body or len(body) > MAX_BODY_BYTES:
+        return None
+    if "application/json" not in request.headers.get("content-type", ""):
+        return None
+    try:
+        value = json.loads(body)
+    except ValueError:
+        return None
+    return value if isinstance(value, (dict, list)) else None
+
+
+def record_user_action(user, request):
+    """Write a public.useractions row for an authenticated request.
+
+    Uses its own session so a failed write cannot leave the request's own
+    transaction unusable, and swallows every error: failing to record an
+    action must never fail the action itself.
+    """
+    try:
+        with db_session() as session:
+            session.add(
+                UserActions(
+                    userid=user.id,
+                    ipaddress=client_ip(request),
+                    url=str(request.url),
+                    time=datetime.now(),
+                    jsonvals=request_body_json(request),
+                    method=request.method[:METHOD_MAX],
+                )
+            )
+            session.commit()
+    except Exception:
+        logger.warning("Failed to record user action", exc_info=True)

--- a/tests/fastapi/test_instrument.py
+++ b/tests/fastapi/test_instrument.py
@@ -389,7 +389,9 @@ class TestInstrumentDelete:
             headers={"api_token": token},
         )
         assert response.status_code == status.HTTP_200_OK
-        return response.json()["instrument"]["id"]
+        result = response.json()
+        assert result["success"] is True, f"Instrument creation failed: {result}"
+        return result["instrument"]["id"]
 
     def test_delete_instrument_success(self):
         """Owner can delete their instrument and its footprints are removed."""

--- a/tests/fastapi/test_instrument.py
+++ b/tests/fastapi/test_instrument.py
@@ -363,6 +363,102 @@ class TestInstrumentAPI:
         assert footprint["footprint"].startswith("POLYGON")
 
 
+class TestInstrumentDelete:
+    """Test suite for deleting instruments."""
+
+    admin_token = "test_token_admin_001"
+    user_token = "test_token_user_002"
+    scientist_token = "test_token_sci_003"
+
+    def get_url(self, endpoint):
+        """Get full URL for an endpoint."""
+        return f"{API_BASE_URL}{API_V1_PREFIX}{endpoint}"
+
+    def _create_instrument(self, token, name):
+        """Create a Circular instrument and return its id."""
+        response = requests.post(
+            self.get_url("/instruments"),
+            json={
+                "instrument_name": name,
+                "nickname": name[:20],
+                "instrument_type": InstrumentType.photometric.value,
+                "footprint_type": "Circular",
+                "unit": "deg",
+                "radius": 1.0,
+            },
+            headers={"api_token": token},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        return response.json()["instrument"]["id"]
+
+    def test_delete_instrument_success(self):
+        """Owner can delete their instrument and its footprints are removed."""
+        instrument_id = self._create_instrument(
+            self.admin_token, "Deletable Telescope"
+        )
+
+        response = requests.delete(
+            self.get_url(f"/instruments/{instrument_id}"),
+            headers={"api_token": self.admin_token},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["deleted_id"] == instrument_id
+        assert body["deleted_footprints"] >= 1
+
+        # It should no longer exist.
+        check = requests.get(
+            self.get_url(f"/instruments?id={instrument_id}"),
+            headers={"api_token": self.admin_token},
+        )
+        assert check.status_code == status.HTTP_200_OK
+        assert check.json() == []
+
+    def test_delete_instrument_not_found(self):
+        """Deleting a non-existent instrument returns 404."""
+        response = requests.delete(
+            self.get_url("/instruments/999999"),
+            headers={"api_token": self.admin_token},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_instrument_without_auth(self):
+        """Deleting without authentication returns 401."""
+        response = requests.delete(self.get_url("/instruments/1"))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_delete_instrument_forbidden_for_non_owner(self):
+        """A non-admin cannot delete another user's instrument."""
+        instrument_id = self._create_instrument(self.user_token, "User Owned Deletable")
+
+        response = requests.delete(
+            self.get_url(f"/instruments/{instrument_id}"),
+            headers={"api_token": self.scientist_token},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_admin_can_delete_others_instrument(self):
+        """An admin can delete an instrument submitted by another user."""
+        instrument_id = self._create_instrument(self.user_token, "Admin Removable")
+
+        response = requests.delete(
+            self.get_url(f"/instruments/{instrument_id}"),
+            headers={"api_token": self.admin_token},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["deleted_id"] == instrument_id
+
+    def test_delete_instrument_referenced_by_pointing(self):
+        """An instrument referenced by pointings cannot be deleted (409)."""
+        # Seeded instrument 1 is referenced by several pointings in test data.
+        response = requests.delete(
+            self.get_url("/instruments/1"),
+            headers={"api_token": self.admin_token},
+        )
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "pointing" in response.json()["message"].lower()
+
+
 class TestInstrumentAPIValidation:
     """Test validation of instrument API endpoints."""
 

--- a/tests/test-data.sql
+++ b/tests/test-data.sql
@@ -49,7 +49,7 @@ VALUES
 -- Insert test groups
 INSERT INTO public.groups (id, name, datecreated)
 VALUES
-    (1, 'admin', NOW()),
+    (1, 'ADMIN', NOW()),
     (2, 'researchers', NOW()),
     (3, 'observers', NOW());
 

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,186 @@
+"""Unit tests for audit recording."""
+
+import json
+
+import pytest
+from starlette.requests import Request
+
+from server.utils import audit
+
+
+def make_request(
+    method="GET",
+    path="/api/v1/pointings",
+    query=b"",
+    headers=None,
+    client=("10.0.0.9", 51234),
+    body=None,
+):
+    """Build a Starlette Request without going through the server."""
+    raw_headers = [
+        (key.lower().encode(), value.encode()) for key, value in (headers or {}).items()
+    ]
+    request = Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "query_string": query,
+            "headers": raw_headers,
+            "client": client,
+            "scheme": "https",
+            "server": ("treasuremap.space", 443),
+        }
+    )
+    if body is not None:
+        # FastAPI buffers the body onto the request before dependencies run.
+        request._body = body
+    return request
+
+
+class TestClientIP:
+    def test_prefers_first_forwarded_hop(self):
+        request = make_request(headers={"X-Forwarded-For": "203.0.113.5, 10.0.0.1"})
+        assert audit.client_ip(request) == "203.0.113.5"
+
+    def test_falls_back_to_peer_address(self):
+        assert audit.client_ip(make_request()) == "10.0.0.9"
+
+    def test_truncates_to_column_width(self):
+        request = make_request(headers={"X-Forwarded-For": "x" * 80})
+        assert len(audit.client_ip(request)) == audit.IPADDRESS_MAX
+
+    def test_none_without_client(self):
+        assert audit.client_ip(make_request(client=None)) is None
+
+
+class TestRequestBodyJSON:
+    def test_reads_buffered_json_object(self):
+        request = make_request(
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=b'{"graceid": "S190425z"}',
+        )
+        assert audit.request_body_json(request) == {"graceid": "S190425z"}
+
+    def test_reads_json_array(self):
+        request = make_request(
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=b"[1, 2]",
+        )
+        assert audit.request_body_json(request) == [1, 2]
+
+    def test_none_when_no_body(self):
+        assert audit.request_body_json(make_request()) is None
+
+    def test_none_for_form_encoded(self):
+        request = make_request(
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=b"username=a&password=b",
+        )
+        assert audit.request_body_json(request) is None
+
+    def test_none_for_oversized_body(self):
+        oversized = json.dumps({"blob": "x" * audit.MAX_BODY_BYTES}).encode()
+        request = make_request(
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=oversized,
+        )
+        assert audit.request_body_json(request) is None
+
+    def test_none_for_malformed_json(self):
+        request = make_request(
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=b"{not json",
+        )
+        assert audit.request_body_json(request) is None
+
+    def test_none_for_scalar_json(self):
+        request = make_request(
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=b'"just a string"',
+        )
+        assert audit.request_body_json(request) is None
+
+
+class FakeSession:
+    def __init__(self, fail_on_commit=False):
+        self.added = []
+        self.committed = False
+        self.fail_on_commit = fail_on_commit
+
+    def add(self, row):
+        self.added.append(row)
+
+    def commit(self):
+        if self.fail_on_commit:
+            raise RuntimeError("database is down")
+        self.committed = True
+
+
+@pytest.fixture
+def captured_session(monkeypatch):
+    """Swap the audit module's session factory for an in-memory double."""
+    from contextlib import contextmanager
+
+    session = FakeSession()
+
+    @contextmanager
+    def fake_db_session():
+        yield session
+
+    monkeypatch.setattr(audit, "db_session", fake_db_session)
+    return session
+
+
+class FakeUser:
+    id = 370
+    username = "kwynn"
+
+
+class TestRecordUserAction:
+    def test_writes_expected_row(self, captured_session):
+        request = make_request(
+            method="POST",
+            path="/api/v1/pointings",
+            headers={
+                "Content-Type": "application/json",
+                "X-Forwarded-For": "203.0.113.5",
+            },
+            body=b'{"graceid": "S190425z"}',
+        )
+
+        audit.record_user_action(FakeUser(), request)
+
+        assert captured_session.committed
+        (row,) = captured_session.added
+        assert row.userid == 370
+        assert row.ipaddress == "203.0.113.5"
+        assert row.url == "https://treasuremap.space/api/v1/pointings"
+        assert row.method == "POST"
+        assert row.jsonvals == {"graceid": "S190425z"}
+        assert row.time is not None
+
+    def test_records_query_string_in_url(self, captured_session):
+        request = make_request(query=b"graceid=S190425z&status=completed")
+        audit.record_user_action(FakeUser(), request)
+        (row,) = captured_session.added
+        assert row.url.endswith("?graceid=S190425z&status=completed")
+
+    def test_write_failure_does_not_propagate(self, monkeypatch, caplog):
+        from contextlib import contextmanager
+
+        @contextmanager
+        def failing_db_session():
+            yield FakeSession(fail_on_commit=True)
+
+        monkeypatch.setattr(audit, "db_session", failing_db_session)
+
+        audit.record_user_action(FakeUser(), make_request())
+
+        assert "Failed to record user action" in caplog.text

--- a/tests/unit/test_get_current_user.py
+++ b/tests/unit/test_get_current_user.py
@@ -1,0 +1,87 @@
+"""Unit tests for token resolution in get_current_user."""
+
+import pytest
+from fastapi import HTTPException
+
+from server.auth import auth
+from tests.unit.test_audit import FakeUser, make_request
+
+
+class FakeQuery:
+    """Returns whatever the fake session was primed with."""
+
+    def __init__(self, result):
+        self.result = result
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self.result
+
+
+class FakeDB:
+    def __init__(self, result):
+        self.result = result
+        self.queries = 0
+
+    def query(self, *args, **kwargs):
+        self.queries += 1
+        return FakeQuery(self.result)
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Capture calls to record_user_action instead of writing to the database."""
+    calls = []
+    monkeypatch.setattr(
+        auth, "record_user_action", lambda user, request: calls.append((user, request))
+    )
+    return calls
+
+
+class TestGetCurrentUser:
+    def test_api_token_header_resolves_user(self, recorded):
+        user = FakeUser()
+        request = make_request()
+
+        result = auth.get_current_user(
+            request=request, api_token="valid", jwt_token=None, db=FakeDB(user)
+        )
+
+        assert result is user
+        assert recorded == [(user, request)]
+
+    def test_bearer_value_falls_back_to_api_token(self, recorded):
+        user = FakeUser()
+
+        result = auth.get_current_user(
+            request=make_request(),
+            api_token=None,
+            jwt_token="an-opaque-api-token",
+            db=FakeDB(user),
+        )
+
+        assert result is user
+        assert len(recorded) == 1
+
+    def test_no_token_raises_401(self, recorded):
+        with pytest.raises(HTTPException) as excinfo:
+            auth.get_current_user(
+                request=make_request(), api_token=None, jwt_token=None, db=FakeDB(None)
+            )
+
+        assert excinfo.value.status_code == 401
+        assert recorded == []
+
+    def test_unknown_token_raises_401(self, recorded):
+        with pytest.raises(HTTPException) as excinfo:
+            auth.get_current_user(
+                request=make_request(),
+                api_token="nope",
+                jwt_token=None,
+                db=FakeDB(None),
+            )
+
+        assert excinfo.value.status_code == 401
+        assert recorded == []


### PR DESCRIPTION
Add DELETE /api/v1/instruments/{id}, restricted to the instrument's submitter or an admin. Removes the instrument's footprint CCD rows and refuses with 409 if any pointing still references the instrument, to avoid orphaning observation records.