### PR TITLE
Fix fastapi test race.

### DIFF
--- a/.github/workflows/fastapi-tests.yml
+++ b/.github/workflows/fastapi-tests.yml
@@ -46,7 +46,10 @@ jobs:
 
     - name: Wait for database to be ready
       run: |
-        timeout 120 bash -c 'until docker compose -f server/docker-compose.yml -p gwtm exec -T db pg_isready -U $DB_USER -d $DB_NAME; do sleep 5; done'
+        # -h forces TCP. Without it pg_isready uses the unix socket, which the
+        # entrypoint's temporary init server also answers, so the gate can pass
+        # before postgres has restarted with TCP listening.
+        timeout 180 bash -c 'until docker compose -f server/docker-compose.yml -p gwtm exec -T db pg_isready -h 127.0.0.1 -p 5432 -U $DB_USER -d $DB_NAME; do sleep 3; done'
 
     - name: Enable PostGIS extension
       run: |

--- a/server/db/models/users.py
+++ b/server/db/models/users.py
@@ -19,7 +19,10 @@ class Users(Base):
     verification_key = Column(String(128))
 
     def set_password(self, password):
-        self.password_hash = generate_password_hash(password)
+        # The method is pinned rather than left to the library default: werkzeug
+        # 3 defaults to scrypt, whose 162-character output does not fit
+        # password_hash. Existing pbkdf2 hashes stay verifiable either way.
+        self.password_hash = generate_password_hash(password, method="pbkdf2:sha256")
 
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U ${DB_USER} -d ${DB_NAME}"]
       interval: 10s
       timeout: 15s
       retries: 5


### PR DESCRIPTION
Pin default password hashing to pbkdf2:sha256 in anticipation of werkzeug library upgrade.